### PR TITLE
Gitignore debugbar files

### DIFF
--- a/storage/debugbar/.gitignore
+++ b/storage/debugbar/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Every posts 's page refresh gets severals files in storage/debugbar
This .gitignore file here will avoid that